### PR TITLE
Fix product sizing arrays

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -28,8 +28,8 @@ class ProductController extends Controller
             'price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id'
         ]);
-        $data = $request->only('name','price','category_id','description');
-        $data['sizes'] = json_encode($request->input('sizes', []));
+        $data = $request->only('name', 'price', 'category_id', 'description');
+        $data['sizes'] = $request->input('sizes', []);
         if($request->hasFile('image')) {
             $data['image'] = $request->file('image')->store('products','public');
         }
@@ -50,8 +50,8 @@ class ProductController extends Controller
             'price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id'
         ]);
-        $data = $request->only('name','price','category_id','description');
-        $data['sizes'] = json_encode($request->input('sizes', []));
+        $data = $request->only('name', 'price', 'category_id', 'description');
+        $data['sizes'] = $request->input('sizes', []);
         if($request->hasFile('image')) {
             $data['image'] = $request->file('image')->store('products','public');
         }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -22,6 +22,21 @@ class Product extends Model
         'sizes' => 'array',
     ];
 
+    /**
+     * Ensure the sizes attribute is always returned as an array.
+     * This also supports legacy records that may contain a
+     * JSON encoded string due to previous double encoding.
+     */
+    public function getSizesAttribute($value)
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        $decoded = json_decode($value, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
     public function category()
     {
         return $this->belongsTo(Category::class);

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -20,7 +20,7 @@ class ProductSeeder extends Seeder
             'name' => 'Sample Product',
             'description' => 'A sample product',
             'price' => 1000,
-            'sizes' => json_encode(['Small','Medium','Large','Extra Large'])
+            'sizes' => ['Small', 'Medium', 'Large', 'Extra Large'],
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- decode double encoded `sizes` attribute
- store array values for product sizes
- save sizes without encoding when creating/updating products

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580cc07c688323ab1ed29864c36075