### PR TITLE
Implement Sub Admin Management

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        $users = User::where('role', 'sub')->paginate(10);
+        return view('admin.users.index', compact('users'));
+    }
+
+    public function create()
+    {
+        return view('admin.users.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|min:6',
+        ]);
+
+        User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+            'role' => 'sub',
+        ]);
+
+        return redirect()->route('admin.users.index')
+            ->with('success', 'Sub admin created successfully.');
+    }
+
+    public function edit(User $user)
+    {
+        if ($user->role !== 'sub') {
+            abort(404);
+        }
+        return view('admin.users.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user)
+    {
+        if ($user->role !== 'sub') {
+            abort(404);
+        }
+
+        $request->validate([
+            'name' => 'required',
+            'email' => 'required|email|unique:users,email,' . $user->id,
+            'password' => 'nullable|min:6',
+        ]);
+
+        $data = $request->only('name', 'email');
+        if ($request->filled('password')) {
+            $data['password'] = Hash::make($request->password);
+        }
+        $user->update($data);
+
+        return redirect()->route('admin.users.index')
+            ->with('success', 'Sub admin updated successfully.');
+    }
+
+    public function destroy(User $user)
+    {
+        if ($user->role !== 'sub') {
+            abort(404);
+        }
+        $user->delete();
+        return redirect()->route('admin.users.index')
+            ->with('success', 'Sub admin deleted successfully.');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -27,5 +27,19 @@ class DatabaseSeeder extends Seeder
             'password' => Hash::make('password'),
             'role' => 'main'
         ]);
+
+        User::create([
+            'name' => 'Sub Admin One',
+            'email' => 'sub1@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'sub'
+        ]);
+
+        User::create([
+            'name' => 'Sub Admin Two',
+            'email' => 'sub2@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'sub'
+        ]);
     }
 }

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -73,7 +73,7 @@
                     </li>
                     @if(Auth::user()->role === 'main')
                     <li class="nav-item">
-                        <a href="#" class="nav-link {{ request()->is('admin/users*') ? 'active' : '' }}">
+                        <a href="{{ route('admin.users.index') }}" class="nav-link {{ request()->is('admin/users*') ? 'active' : '' }}">
                             <i class="nav-icon fas fa-users"></i>
                             <p>User Management</p>
                         </a>
@@ -88,6 +88,18 @@
     <div class="content-wrapper">
         <section class="content pt-3">
             <div class="container-fluid">
+                @if(session('success'))
+                    <div class="alert alert-success">{{ session('success') }}</div>
+                @endif
+                @if($errors->any())
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            @foreach($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
                 @yield('content')
             </div>
         </section>

--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -1,0 +1,22 @@
+@extends('admin.layout')
+
+@section('content')
+<div class="card">
+    <div class="card-header">New Sub Admin</div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('admin.users.store') }}">
+            @csrf
+            <div class="form-group">
+                <input type="text" name="name" class="form-control" placeholder="Name" value="{{ old('name') }}" required>
+            </div>
+            <div class="form-group">
+                <input type="email" name="email" class="form-control" placeholder="Email" value="{{ old('email') }}" required>
+            </div>
+            <div class="form-group">
+                <input type="password" name="password" class="form-control" placeholder="Password" required>
+            </div>
+            <button class="btn btn-primary mt-3">Save</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,24 @@
+@extends('admin.layout')
+
+@section('content')
+<div class="card">
+    <div class="card-header">Edit Sub Admin</div>
+    <div class="card-body">
+        <form method="POST" action="{{ route('admin.users.update', $user) }}">
+            @csrf
+            @method('PUT')
+            <div class="form-group">
+                <input type="text" name="name" class="form-control" value="{{ old('name', $user->name) }}" required>
+            </div>
+            <div class="form-group">
+                <input type="email" name="email" class="form-control" value="{{ old('email', $user->email) }}" required>
+            </div>
+            <div class="form-group">
+                <input type="password" name="password" class="form-control" placeholder="New Password">
+                <small class="form-text text-muted">Leave blank to keep current password</small>
+            </div>
+            <button class="btn btn-primary mt-3">Update</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,21 +1,34 @@
 @extends('admin.layout')
 
 @section('content')
-<h1 class="mb-3">User Management</h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="m-0">Sub Admins</h1>
+    <a href="{{ route('admin.users.create') }}" class="btn btn-primary">New</a>
+</div>
 <table class="table table-bordered table-striped">
     <thead>
         <tr>
             <th>Name</th>
             <th>Email</th>
-            <th>Role</th>
+            <th class="text-right">Actions</th>
         </tr>
     </thead>
     <tbody>
+    @foreach($users as $user)
         <tr>
-            <td>Example User</td>
-            <td>user@example.com</td>
-            <td>main</td>
+            <td>{{ $user->name }}</td>
+            <td>{{ $user->email }}</td>
+            <td class="text-right">
+                <a href="{{ route('admin.users.edit', $user) }}" class="btn btn-sm btn-secondary">Edit</a>
+                <form method="POST" action="{{ route('admin.users.destroy', $user) }}" class="d-inline" onsubmit="return confirm('Delete this user?');">
+                    @csrf
+                    @method('DELETE')
+                    <button class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
         </tr>
+    @endforeach
     </tbody>
 </table>
+{{ $users->links() }}
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Admin\CategoryController as AdminCategory;
 use App\Http\Controllers\Admin\ProductController as AdminProduct;
 use App\Http\Controllers\Admin\OrderController as AdminOrder;
 use App\Http\Controllers\Admin\FeedbackController as AdminFeedback;
+use App\Http\Controllers\Admin\UserController as AdminUser;
 use Illuminate\Support\Facades\Auth;
 
 Route::get('/', [HomeController::class, 'index'])->name('home');
@@ -48,6 +49,11 @@ Route::prefix('admin')->group(function () {
         Route::resource('products', AdminProduct::class, ['as' => 'admin']);
         Route::resource('orders', AdminOrder::class, ['only' => ['index','update'], 'as' => 'admin']);
         Route::get('feedback', [AdminFeedback::class, 'index'])->name('admin.feedback.index');
+
+        Route::middleware('is_admin')->group(function () {
+            Route::resource('users', AdminUser::class, ['except' => ['show'], 'as' => 'admin']);
+        });
+
         Route::post('logout', function () {
             Auth::logout();
             return redirect()->route('admin.login');


### PR DESCRIPTION
## Summary
- add controller for managing sub admins
- seed database with sub admin accounts
- enable flash messages in admin layout and link to user routes
- restrict user management routes with `is_admin` middleware
- add CRUD views for sub admins using AdminLTE

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580eb55de88323a0ef77dd81fa1014