### PR TITLE
Add extensive seed data

### DIFF
--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -13,6 +13,14 @@ class CategorySeeder extends Seeder
             ['name' => 'Shirts'],
             ['name' => 'Pants'],
             ['name' => 'Accessories'],
+            ['name' => 'Shoes'],
+            ['name' => 'Hats'],
+            ['name' => 'Outerwear'],
+            ['name' => 'Underwear'],
+            ['name' => 'Socks'],
+            ['name' => 'Bags'],
+            ['name' => 'Belts'],
+            ['name' => 'Jewelry'],
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,8 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Database\Seeders\CategorySeeder;
 use Database\Seeders\ProductSeeder;
+use Database\Seeders\OrderSeeder;
+use Database\Seeders\FeedbackSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,6 +21,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             CategorySeeder::class,
             ProductSeeder::class,
+            OrderSeeder::class,
+            FeedbackSeeder::class,
         ]);
 
         User::create([

--- a/database/seeders/FeedbackSeeder.php
+++ b/database/seeders/FeedbackSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Feedback;
+use App\Models\Product;
+use Faker\Factory as Faker;
+
+class FeedbackSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $faker = Faker::create();
+        $products = Product::all();
+        if ($products->isEmpty()) {
+            return;
+        }
+
+        for ($i = 0; $i < 15; $i++) {
+            $product = $products->random();
+            Feedback::create([
+                'product_id'    => $product->id,
+                'customer_name' => $faker->name(),
+                'customer_email'=> $faker->safeEmail(),
+                'text'          => $faker->sentence(),
+                'rating'        => $faker->numberBetween(1,5),
+            ]);
+        }
+    }
+}

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use Faker\Factory as Faker;
+
+class OrderSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $faker = Faker::create();
+        $products = Product::all();
+        if ($products->isEmpty()) {
+            return;
+        }
+
+        for ($i = 0; $i < 25; $i++) {
+            $order = Order::create([
+                'customer_name'  => $faker->name(),
+                'customer_email' => $faker->safeEmail(),
+                'address'        => $faker->streetAddress(),
+                'city'           => $faker->city(),
+                'phone'          => $faker->phoneNumber(),
+                'total_price'    => 0,
+                'status'         => $faker->randomElement(['pending','shipped','completed'])
+            ]);
+
+            $itemsCount = rand(1,3);
+            $total = 0;
+            for ($j = 0; $j < $itemsCount; $j++) {
+                $product = $products->random();
+                $quantity = rand(1,3);
+                $price = $product->price;
+                OrderItem::create([
+                    'order_id'   => $order->id,
+                    'product_id' => $product->id,
+                    'quantity'   => $quantity,
+                    'price'      => $price,
+                    'size'       => $product->sizes[array_rand($product->sizes)] ?? null,
+                ]);
+                $total += $price * $quantity;
+            }
+            $order->update(['total_price' => $total]);
+        }
+    }
+}

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -4,23 +4,36 @@ namespace Database\Seeders;
 
 use App\Models\Product;
 use App\Models\Category;
+use Illuminate\Support\Facades\Storage;
+use Faker\Factory as Faker;
 use Illuminate\Database\Seeder;
 
 class ProductSeeder extends Seeder
 {
     public function run(): void
     {
-        $category = Category::first();
-        if(!$category) {
-            $category = Category::create(['name' => 'General']);
+        $faker = Faker::create();
+
+        $categories = Category::all();
+        if ($categories->isEmpty()) {
+            $categories = collect([Category::create(['name' => 'General'])]);
         }
 
-        Product::create([
-            'category_id' => $category->id,
-            'name' => 'Sample Product',
-            'description' => 'A sample product',
-            'price' => 1000,
-            'sizes' => ['Small', 'Medium', 'Large', 'Extra Large'],
-        ]);
+        for ($i = 1; $i <= 60; $i++) {
+            $imagePath = "products/product_{$i}.png";
+            if (!Storage::disk('public')->exists($imagePath)) {
+                $data = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wcAAgMBAp6e6wAAAABJRU5ErkJggg==');
+                Storage::disk('public')->put($imagePath, $data);
+            }
+
+            Product::create([
+                'category_id' => $categories->random()->id,
+                'name' => $faker->words(3, true),
+                'description' => $faker->sentence(),
+                'price' => $faker->randomFloat(2, 5, 100),
+                'image' => $imagePath,
+                'sizes' => ['Small', 'Medium', 'Large', 'Extra Large'],
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand categories list
- seed 60 products with placeholder images
- add order and feedback seeders
- wire new seeders in DatabaseSeeder

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581544ad208323b4c42814ea69f15e