### PR TITLE
Add order confirmation email

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Mail\OrderPlaced;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Product;
@@ -57,10 +58,8 @@ class OrderController extends Controller
 
         session()->forget('cart');
 
-        // Fake email via log
-        Mail::raw('Order '.$order->id.' placed.', function($message) use ($order) {
-            $message->to($order->customer_email);
-        });
+        // Send order confirmation email
+        Mail::to($order->customer_email)->send(new OrderPlaced($order));
 
         return redirect()->route('orders.confirmation', $order);
     }

--- a/app/Mail/OrderPlaced.php
+++ b/app/Mail/OrderPlaced.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class OrderPlaced extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public Order $order;
+
+    public function __construct(Order $order)
+    {
+        $this->order = $order;
+    }
+
+    public function build()
+    {
+        return $this->subject('Order #' . $this->order->id . ' Confirmation')
+            ->markdown('emails.order_placed');
+    }
+}

--- a/resources/views/emails/order_placed.blade.php
+++ b/resources/views/emails/order_placed.blade.php
@@ -1,0 +1,22 @@
+@component('mail::message')
+# Order Confirmation
+
+Thank you for your order, {{ $order->customer_name }}.
+
+@component('mail::table')
+| Product | Quantity | Price | Size |
+|---------|---------:|------:|------|
+@foreach($order->items as $item)
+| {{ $item->product->name }} | {{ $item->quantity }} | PKR {{ $item->price }} | {{ $item->size ?? '-' }} |
+@endforeach
+@endcomponent
+
+**Total:** PKR {{ $order->total_price }}
+
+@component('mail::button', ['url' => route('orders.confirmation', $order)])
+View Order
+@endcomponent
+
+Thanks,
+{{ config('app.name') }}
+@endcomponent

--- a/tests/Feature/OrderEmailTest.php
+++ b/tests/Feature/OrderEmailTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Mail\OrderPlaced;
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Support\Facades\Mail;
+
+it('sends order confirmation email', function () {
+    Mail::fake();
+
+    $category = Category::create(['name' => 'Test Category']);
+    $product = Product::create([
+        'category_id' => $category->id,
+        'name' => 'Test Product',
+        'price' => 10,
+        'description' => 'desc',
+        'sizes' => []
+    ]);
+
+    $this->withSession(['cart' => [
+        $product->id => [
+            'product' => $product,
+            'quantity' => 1,
+            'size' => null
+        ]
+    ]]);
+
+    $this->post('/checkout', [
+        'customer_name' => 'John Doe',
+        'customer_email' => 'john@example.com',
+        'address' => '123 Street',
+        'city' => 'Town',
+        'phone' => '123456'
+    ])->assertRedirect();
+
+    Mail::assertSent(OrderPlaced::class);
+});


### PR DESCRIPTION
## Summary
- notify customers with `OrderPlaced` mailer when they place an order
- create markdown email template
- cover email sending with a feature test

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583e7f71a883239e4a69ffcf0a1809